### PR TITLE
Add `RUnit` to `Suggests`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -7,7 +7,7 @@ Description: A tool for the identification of differentially coexpressed links (
 Maintainer: Wenbin Wei <wenbin.wei2@durham.ac.uk>
 Depends: R (>= 3.5), WGCNA, SummarizedExperiment
 Imports: stats, DiffCorr, psych, igraph, BiocGenerics
-Suggests: GEOquery
+Suggests: GEOquery, RUnit
 URL: https://github.com/hidelab/diffcoexp
 biocViews: GeneExpression, DifferentialExpression, Transcription, Microarray, OneChannel, TwoChannel, RNASeq, Sequencing, Coverage, ImmunoOncology
 License: GPL (>2)


### PR DESCRIPTION
It seems `RUnit` is a transitive dependency that must be explicitly declared for Bioc 3.18, because of `_R_CHECK_SUGGESTS_ONLY_=true`

See https://support.bioconductor.org/p/9153573/#9153581 for more details.